### PR TITLE
pass C++11 flag to castxml

### DIFF
--- a/pygccxml/parser/source_reader.py
+++ b/pygccxml/parser/source_reader.py
@@ -161,7 +161,10 @@ class source_reader_t(object):
         else:
 
             # On mac or linux, use gcc or clang (the flag is the same)
-            cmd.append('--castxml-cc-gnu ' + self.__config.compiler_path)
+            if '-std=c++11' in self.__config.cflags:
+                cmd.append('--castxml-cc-gnu ' + '"(" ' + self.__config.compiler_path + ' -std=c++11 ")"')
+            else:
+                cmd.append('--castxml-cc-gnu ' + self.__config.compiler_path)
 
         # Tell castxml to output xml compatible files with gccxml
         # so that we can parse them with pygccxml


### PR DESCRIPTION
Just putting in "-std=c++11" in cflags is not sufficient. Without this change, I get errors like these:
```
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/stdexcept:45:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__config:234:20: error: 
      cannot combine with previous 'char16_t' declaration specifier
typedef __char16_t char16_t;
                   ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__config:235:20: error: 
      cannot combine with previous 'char32_t' declaration specifier
typedef __char32_t char32_t;
                   ^
2 errors generated.
```
This fix should probably generalized to cover C++14 and C++17 as well.