### PR TITLE
Python2.6 compatibility and gcc + castxml fixes

### DIFF
--- a/unittests/autoconfig.py
+++ b/unittests/autoconfig.py
@@ -56,6 +56,11 @@ class cxx_parsers_cfg(object):
         if 'msvc9' == gccxml.compiler:
             gccxml.define_symbols.append('_HAS_TR1=0')
 
+if cxx_parsers_cfg.gccxml.xml_generator:
+    generator_name = cxx_parsers_cfg.gccxml.xml_generator
+if cxx_parsers_cfg.gccxml.xml_generator_path:
+    generator_path = cxx_parsers_cfg.gccxml.xml_generator_path
+
 print(
     '%s configured to simulate compiler %s' %
     (generator_name.title(), cxx_parsers_cfg.gccxml.compiler))

--- a/unittests/data/remove_template_defaults.hpp
+++ b/unittests/data/remove_template_defaults.hpp
@@ -8,7 +8,7 @@
 
 #if defined( __llvm__ )
 
-    // This is mostly for CastXML with never compilers
+    // This is mostly for CastXML with newer compilers
 
     // When parsing with clang//llvm use the new c++11 (c++0x even ?)
     // unordered_maps and unordered_sets
@@ -38,9 +38,31 @@
     // This is mostly for GCCXML (when using old compilers)
 
     #if defined( __GNUC__ )
-        #include <ext/hash_set>
-        #include <ext/hash_map>
-        #define HASH_XXX_NS __gnu_cxx
+        #if ((__GNUC__ > 4) || \
+             (__GNUC__ == 4 && __GNUC_MINOR__ > 4) || \
+             (__GNUC__ == 4 && __GNUC_MINOR__ == 4 && __GNUC_PATCHLEVEL__ == 7)) && \
+            defined(__castxml__)
+
+            // Use TR1 containers for gcc >= 4.4.7 + castxml
+            // (this might work on older versions of gcc too, needs testing)
+            #include <tr1/unordered_map>
+            #include <tr1/unordered_set>
+            #define HASH_XXX_NS std::tr1
+
+            #define HASH_XXX_UMAP unordered_map
+            #define HASH_XXX_USET unordered_set
+            #define HASH_XXX_UMMAP unordered_multimap
+            #define HASH_XXX_UMMSET unordered_multiset
+        #else
+            #include <ext/hash_set>
+            #include <ext/hash_map>
+            #define HASH_XXX_NS __gnu_cxx
+
+            #define HASH_XXX_UMAP hash_map
+            #define HASH_XXX_USET hash_set
+            #define HASH_XXX_UMMAP hash_multimap
+            #define HASH_XXX_UMMSET hash_multiset
+        #endif
     #else
         #include <hash_set>
         #include <hash_map>
@@ -49,12 +71,12 @@
         #else
             #define HASH_XXX_NS stdext
         #endif
-    #endif
 
-    #define HASH_XXX_UMAP hash_map
-    #define HASH_XXX_USET hash_set
-    #define HASH_XXX_UMMAP hash_multimap
-    #define HASH_XXX_UMMSET hash_multiset
+        #define HASH_XXX_UMAP hash_map
+        #define HASH_XXX_USET hash_set
+        #define HASH_XXX_UMMAP hash_multimap
+        #define HASH_XXX_UMMSET hash_multiset
+    #endif
 
 #endif
 

--- a/unittests/parser_test_case.py
+++ b/unittests/parser_test_case.py
@@ -4,10 +4,8 @@
 # See http://www.boost.org/LICENSE_1_0.txt
 
 import pprint
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import sys
+import unittest
 import autoconfig
 
 
@@ -84,3 +82,10 @@ class parser_test_case_t(unittest.TestCase):
             (calldef.name,
              pprint.pformat([delc.name for delc in exception_decls]),
              pprint.pformat([delc.name for delc in exceptions_indeed])))
+
+if sys.version_info < (2, 7, 0):
+    # Python2.6 does not have the following methods in the unittest module
+    parser_test_case_t.assertIn = \
+        lambda parser, a1, a2, *args: parser.assertTrue(a1 in a2, args)
+    parser_test_case_t.assertNotIn = \
+        lambda parser, a1, a2, *args: parser.assertFalse(a1 in a2, args)


### PR DESCRIPTION
`parser_test_case.py`
* Monkey-patch `assertIn` and `assertNotIn` methods for Python2.6

`remove_template_defaults.hpp`
* Use `std::tr1` unordered containers for gcc >= 4.4.7 and castxml
* I've tested the following combinations
 * gcc 4.4.7 + gccxml
 * gcc 4.9 + castxml

`autoconfig.py`
* Cosmetic fix for generator name printed to stdout when launching unit tests