### PR TITLE
Typo fixes

### DIFF
--- a/pygccxml/binary_parsers/undname.py
+++ b/pygccxml/binary_parsers/undname.py
@@ -187,8 +187,9 @@ class undname_creator_t(object):
                 # ugly hack, later, I will replace ', ' with ',', so single
                 # space will still exist
                 argsep = ',  '
-            return argsep.join(map(self.__format_type_as_undecorated(
-                type_, True, hint), argtypes))
+            return argsep.join(
+                map(lambda type_: \
+                    self.__format_type_as_undecorated(type_, True, hint), argtypes))
 
     def format_calldef(self, calldef, hint):
         calldef_type = calldef.function_type()

--- a/pygccxml/parser/scanner.py
+++ b/pygccxml/parser/scanner.py
@@ -532,7 +532,7 @@ class scanner_t(xml.sax.handler.ContentHandler):
         self.__read_byte_offset(decl, attrs)
         return decl
 
-    __read_field = __read_variable  # just a synonim
+    __read_field = __read_variable  # just a synonym
 
     def __read_class_impl(self, class_type, attrs):
         name = attrs.get(XML_AN_NAME, '')


### PR DESCRIPTION
`undname_creator_t.format_argtypes` contained an undefined variable named `type_`.
Comment spelling fix in `scanner.py`