### PR TITLE
Fix for typedef'd unnamed class/struct

### DIFF
--- a/pygccxml/declarations/__init__.py
+++ b/pygccxml/declarations/__init__.py
@@ -18,6 +18,7 @@ from .declaration import declaration_t
 from .scopedef import scopedef_t
 from .enumeration import enumeration_t
 from .namespace import namespace_t
+from .typedef import typedef_t
 
 from .class_declaration import class_t
 from .class_declaration import CLASS_TYPES

--- a/unittests/data/classes.hpp
+++ b/unittests/data/classes.hpp
@@ -7,10 +7,16 @@
 #define __classes_hpp__
 
 struct cls{};
+typedef struct {} cls2;
+typedef class {
+   int i;
+} cls3;
 
 namespace ns{
 
     struct nested_cls{};
+    typedef class {} nested_cls2;
+    typedef struct nested_cls3 {} nested_cls3;
 
 }
 

--- a/unittests/declaration_matcher_tester.py
+++ b/unittests/declaration_matcher_tester.py
@@ -8,6 +8,7 @@ import parser_test_case
 
 from pygccxml import parser
 from pygccxml import declarations
+from pygccxml import utils
 
 
 class tester_t(parser_test_case.parser_test_case_t):
@@ -31,6 +32,19 @@ class tester_t(parser_test_case.parser_test_case_t):
         gns.class_('cls')
         gns.class_('::cls')
 
+    def test_typedefs(self):
+        gns = self.global_ns
+        gns.class_('cls2')
+        if self.config.xml_generator == "castxml":
+            gns.typedef('cls2')
+        gns.class_('::cls2')
+
+        gns.class_('cls3')
+        if self.config.xml_generator == "castxml":
+            gns.typedef('cls3')
+        cls3 = gns.class_('::cls3')
+        cls3.variable('i')
+
     def test_ns1(self):
         gns = self.global_ns
         ns1 = gns.namespace('ns')
@@ -42,6 +56,14 @@ class tester_t(parser_test_case.parser_test_case_t):
         self.assertRaises(Exception, lambda: ns1.class_('::nested_cls'))
         ns1.class_('nested_cls')
         ns1.class_('::ns::nested_cls')
+
+        gns.class_('nested_cls2')
+        self.assertRaises(Exception, lambda: gns.class_('ns::nested_cls2'))
+        gns.class_('::ns::nested_cls2')
+
+        gns.class_('nested_cls3')
+        self.assertRaises(Exception, lambda: gns.class_('ns::nested_cls3'))
+        gns.class_('::ns::nested_cls3')
 
 
 def create_suite():


### PR DESCRIPTION
Unlike GCCXML, CastXML creates two distinct XML nodes for a typedef of
the form

    typedef (class|struct) {} foo;

The first XML node is an unnamed class/struct and the second is a
typedef that refers to the first node. This requires special handling
during parsing so that the name of the typedef is propagated to the
class/struct.