### PR TITLE
Fix unqualified enums in default arguments for CastXML

### DIFF
--- a/pygccxml/parser/patcher.py
+++ b/pygccxml/parser/patcher.py
@@ -44,14 +44,18 @@ class default_argument_patcher_t(object):
         if not declarations.is_enum(type_):
             return False
         enum_type = declarations.enum_declaration(type_)
-        return enum_type.has_value_name(arg.default_value)
+        # GCCXML does not qualify an enum value in the default argument
+        # but CastXML does. Split the default value and use only the
+        # enum value for fixing it.
+        return enum_type.has_value_name(
+            arg.default_value.split('::')[-1])
 
     def __fix_unqualified_enum(self, func, arg):
         type_ = declarations.remove_reference(declarations.remove_cv(arg.type))
         enum_type = declarations.enum_declaration(type_)
         return self.__join_names(
             enum_type.parent.decl_string,
-            arg.default_value)
+            arg.default_value.split('::')[-1])
 
     def __is_invalid_integral(self, func, arg):
         type_ = declarations.remove_reference(declarations.remove_cv(arg.type))

--- a/unittests/data/patcher.hpp
+++ b/unittests/data/patcher.hpp
@@ -12,10 +12,18 @@
 namespace ns1{ namespace ns2{
 
 enum fruit{ apple, orange };
+void fix_enum2( fruit arg=apple );
 
 } }
 
 void fix_enum( ns1::ns2::fruit arg=ns1::ns2::apple );
+
+namespace ns3{
+
+using namespace ns1::ns2;
+void fix_enum3( fruit arg=orange );
+
+}
 
 typedef unsigned long long ull;
 void fix_numeric( ull arg=(ull)-1 );

--- a/unittests/patcher_tester.py
+++ b/unittests/patcher_tester.py
@@ -23,48 +23,53 @@ class tester_impl_t(parser_test_case.parser_test_case_t):
     def test_enum_patcher(self):
         fix_enum = self.global_ns.free_fun("fix_enum")
         default_val = fix_enum.arguments[0].default_value
-        if "CastXML" in utils.xml_generator:
-            # Most clean output, no need to patch
-            self.assertTrue(default_val == "ns1::ns2::apple")
-        else:
-            self.assertTrue(default_val == "::ns1::ns2::apple")
+        self.assertEqual(default_val, "::ns1::ns2::apple")
+
+        if 32 == self.architecture or "CastXML" in utils.xml_generator:
+            fix_enum2 = self.global_ns.free_fun("fix_enum2")
+            default_val = fix_enum2.arguments[0].default_value
+            self.assertEqual(default_val, "::ns1::ns2::apple")
+
+            ns1 = self.global_ns.namespace("ns1")
+            ns2 = ns1.namespace("ns2")
+            fix_enum2 = ns2.free_fun("fix_enum2")
+            default_val = fix_enum2.arguments[0].default_value
+            self.assertEqual(default_val, "::ns1::ns2::apple")
+
+            fix_enum3 = self.global_ns.free_fun("fix_enum3")
+            default_val = fix_enum3.arguments[0].default_value
+            self.assertEqual(default_val, "::ns1::ns2::orange")
 
         # double_call = declarations.find_declaration(
         # decls, type=declarations.free_function_t, name='double_call' )
 
     def test_numeric_patcher(self):
-        fix_numeric = self.global_ns.free_fun("fix_numeric")
+        fix_numeric = self.global_ns.free_function("fix_numeric")
         if 32 == self.architecture:
             if "0.9" in utils.xml_generator:
                 if platform.machine() == "x86_64":
-                    self.assertTrue(
-                        fix_numeric.arguments[0].default_value == "-1u",
-                        fix_numeric.arguments[0].default_value)
+                    self.assertEqual(
+                        fix_numeric.arguments[0].default_value, "-1u")
                 else:
                     val = "0xffffffffffffffffu"
-                    self.assertTrue(
-                        fix_numeric.arguments[0].default_value == val,
-                        fix_numeric.arguments[0].default_value)
+                    self.assertEqual(
+                        fix_numeric.arguments[0].default_value, val)
             else:
                 val = "0xffffffffffffffff"
-                self.assertTrue(
-                    fix_numeric.arguments[0].default_value == val,
-                    fix_numeric.arguments[0].default_value)
+                self.assertEqual(
+                    fix_numeric.arguments[0].default_value, val)
         else:
             if "CastXML" in utils.xml_generator:
-                # Most clean output, no need to patch
-                self.assertTrue(
-                    fix_numeric.arguments[0].default_value == "(ull)-1",
-                    fix_numeric.arguments[0].default_value)
+                self.assertEqual(
+                    fix_numeric.arguments[0].default_value, "(ull)-1")
             else:
-                self.assertTrue(
-                    fix_numeric.arguments[0].default_value == "0ffffffff",
-                    fix_numeric.arguments[0].default_value)
+                self.assertEqual(
+                    fix_numeric.arguments[0].default_value, "0ffffffff")
 
     def test_unnamed_enum_patcher(self):
         fix_unnamed = self.global_ns.free_fun("fix_unnamed")
-        self.assertTrue(
-            fix_unnamed.arguments[0].default_value == "int(::fx::unnamed)")
+        self.assertEqual(
+            fix_unnamed.arguments[0].default_value, "int(::fx::unnamed)")
 
     def test_function_call_patcher(self):
         fix_function_call = self.global_ns.free_fun("fix_function_call")
@@ -72,33 +77,33 @@ class tester_impl_t(parser_test_case.parser_test_case_t):
         if "CastXML" in utils.xml_generator:
             # Most clean output, no need to patch
             val = "calc(1, 2, 3)"
-            self.assertTrue(default_val == val)
+            self.assertEqual(default_val, val)
         elif "0.9" in utils.xml_generator:
             val = "function_call::calc(1, 2, 3)"
-            self.assertTrue(default_val == val)
+            self.assertEqual(default_val, val)
         else:
             val = "function_call::calc( 1, 2, 3 )"
-            self.assertTrue(default_val == val)
+            self.assertEqual(default_val, val)
 
     def test_fundamental_patcher(self):
         fcall = self.global_ns.free_fun("fix_fundamental")
         val = "(unsigned int)(::fundamental::eggs)"
-        self.assertTrue(
-            fcall.arguments[0].default_value == val)
+        self.assertEqual(
+            fcall.arguments[0].default_value, val)
 
     def test_constructor_patcher(self):
         typedef__func = self.global_ns.free_fun("typedef__func")
         default_val = typedef__func.arguments[0].default_value
         if "0.9" in utils.xml_generator:
             val = "typedef_::original_name()"
-            self.assertTrue(default_val == val)
+            self.assertEqual(default_val, val)
         elif "CastXML" in utils.xml_generator:
             # Most clean output, no need to patch
             val = "typedef_::alias()"
-            self.assertTrue(default_val == val)
+            self.assertEqual(default_val, val)
         else:
             val = "::typedef_::alias( )"
-            self.assertTrue(default_val == val)
+            self.assertEqual(default_val, val)
         if 32 == self.architecture:
             clone_tree = self.global_ns.free_fun("clone_tree")
             default_values = []
@@ -116,7 +121,7 @@ class tester_impl_t(parser_test_case.parser_test_case_t):
                         "std::allocator<char> > > >((&allocator" +
                         "<std::basic_string<char, std::char_traits<char>, " +
                         "std::allocator<char> > >()))")]
-                self.assertTrue(
+                self.assertIn(
                     clone_tree.arguments[0].default_value in default_values)
 
 


### PR DESCRIPTION
CastXML currently doesn't modify enum names used in default arguments for
functions, it simply uses the same text present in the source file. This
causes compilation failures in bindings generated by pyplusplus in case
of code such as the following:

    namespace ns1
    {
    namespace ns2
    {
        enum color { red };
        void foo(color arg = ns2::red);
    }
    }

In this case, CastXML produces `ns2::red` as the default value while
GCCXML removes the namespace name and sets the default value to `red`.
pygccxml's patcher for unqualified names expects GCCXML's behavior, so
it fails to detect the CastXML output as one needing further
qualification.

Consequently, pyplusplus refers to the default value as `ns2::red`,
which fails compilation because the name needs to be fully qualified as
`ns1::ns2::red`. This fix produces the desired qualified output from
pygccxml with both GCCXML and CastXML.