### PR TITLE
Fix warning in core_class_hierarchy.hpp

### DIFF
--- a/unittests/data/core_class_hierarchy.hpp
+++ b/unittests/data/core_class_hierarchy.hpp
@@ -6,8 +6,6 @@
 #ifndef __core_class_hierarchy_hpp__
 #define __core_class_hierarchy_hpp__
 
-//TODO("To add virtual inheritance case");
-
 namespace core{ namespace class_hierarchy{
 
 class base_t{
@@ -24,10 +22,10 @@ class derived_public_t : public base_t{
 class derived_protected_t : protected base_t{
 };
 
-class derived_private_t : private base_t{
+class derived_private_t : private virtual base_t{
 };
 
-class multi_derived_t : derived_private_t, protected base_t, private other_base_t{
+class multi_derived_t : derived_private_t, protected virtual base_t, private other_base_t{
 };
 
 } }


### PR DESCRIPTION
`core_class_hierarchy.hpp` contains classes with the following
inheritance hierarchy

    derived_private_t -> base_t
    multi_derived_t   -> derived_private_t, base_t

Since `multi_derived_t` contains `base_t` as a direct base and as a base
via `derived_private_t`, this creates warnings about `base_t` being
inaccessible because it's ambiguous which `base_t` instance is being
referred to.

Changed the inheritance hierarchy to `virtual` inheritance so that
`derived_private_t` and `multi_derived_t` inherit `base_t` virtually. Now
there's only a single instance of `base_t` in `multi_derived_t` and the
warning is avoided.

Fixes #46

Change-Id: I3a52a666460bea2cc3c66b1855288d757f93f507