### PR TITLE
Pipe `stderr` when calling `subprocess.Popen`

### DIFF
--- a/pygccxml/parser/config.py
+++ b/pygccxml/parser/config.py
@@ -431,9 +431,11 @@ def create_compiler_path(xml_generator, compiler_path):
         if platform.system() != 'Windows':
             # On windows there is no need for the compiler path
             p = subprocess.Popen(
-                ['which', 'clang++'], stdout=subprocess.PIPE)
+                ['which', 'clang++'], stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE)
             compiler_path = p.stdout.read().decode("utf-8").rstrip()
             p.stdout.close()
+            p.stderr.close()
             # No clang found; use gcc
             if compiler_path == '':
                 compiler_path = '/usr/bin/c++'

--- a/pygccxml/utils/utils.py
+++ b/pygccxml/utils/utils.py
@@ -50,18 +50,24 @@ def find_xml_generator(name=None):
 
     if name is None:
         name = "castxml"
-        p = subprocess.Popen([command, name], stdout=subprocess.PIPE)
+        p = subprocess.Popen([command, name], stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
         path = p.stdout.read().decode("utf-8")
         p.stdout.close()
+        p.stderr.close()
         if path == "":
             name = "gccxml"
-            p = subprocess.Popen([command, name], stdout=subprocess.PIPE)
+            p = subprocess.Popen([command, name], stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
             path = p.stdout.read().decode("utf-8")
             p.stdout.close()
+            p.stderr.close()
     else:
-        p = subprocess.Popen([command, name], stdout=subprocess.PIPE)
+        p = subprocess.Popen([command, name], stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
         path = p.stdout.read().decode("utf-8")
         p.stdout.close()
+        p.stderr.close()
     if path == "":
         raise(Exception(
             "No c++ parser found. Please install castxml or gccxml."))


### PR DESCRIPTION
Code that uses the `which` command to find *castxml* and *clang++* now
pipes `stderr` in addition to `stdout`. This prevents error messages
from being printed if the executables being searched for are not on
`PATH`.