### PR TITLE
Fix errors in -std=c++11 mode

### DIFF
--- a/unittests/data/free_operators.hpp
+++ b/unittests/data/free_operators.hpp
@@ -32,12 +32,12 @@ bool operator!( const number& x ){
 }
 
 number operator*( const number& n,  double i ){
-    number n2 = { n.i * i };
+    number n2 = { static_cast<int>(n.i * i) };
     return n2;
 }
 
 number operator*( double i, const number& n ){
-    number n2 = { n.i * i };
+    number n2 = { static_cast<int>(n.i * i) };
     return n2;
 }
 

--- a/unittests/data/type_traits.hpp
+++ b/unittests/data/type_traits.hpp
@@ -576,12 +576,19 @@ namespace has_trivial_constructor{
 namespace details{
 
     struct const_item{ const int values[10]; };
-
-    void test_const_item( const_item x = const_item() );
-
     struct const_container{ const const_item items[10]; };
 
+#if __cplusplus >= 201103L
+    // C++11 and later must use braces to trigger aggregate initialization.
+    // Using parentheses will cause value-initialization, and since the
+    // two classes above have implicitly deleted default constructors,
+    // that causes default initialization to be performed, which is ill-formed.
+    void test_const_item( const_item x = const_item{} );
+    void test_const_container( const_container x = const_container{} );
+#else
+    void test_const_item( const_item x = const_item() );
     void test_const_container( const_container x = const_container() );
+#endif
 
 }
 


### PR DESCRIPTION
`free_operators.hpp` had a couple of instances of narrowing conversions
within braced initializers, which is ill-formed since C++11.

`type_traits.hpp` had two instances of aggregates being
value-initialized using empty parentheses. Since these aggregates had
implicitly deleted default constructors (due to the presence of `const`
data members), value-initialization performs default-initialization,
which is ill-formed. We need aggregate-initialization to be performed,
so the initialization must use braces instead of parentheses for C++11
and later.