### PR TITLE
Fix patching of enums in default arguments for C++03

### DIFF
--- a/pygccxml/parser/source_reader.py
+++ b/pygccxml/parser/source_reader.py
@@ -89,6 +89,7 @@ class source_reader_t(object):
         self.__join_decls = join_decls
         self.__search_directories = []
         self.__config = config
+        self.__cxx_std = utils.cxx_standard(config.cflags)
         self.__search_directories.append(config.working_directory)
         self.__search_directories.extend(config.include_paths)
         if not cache:
@@ -159,30 +160,12 @@ class source_reader_t(object):
             # On mac or linux, use gcc or clang (the flag is the same)
             cmd.append('--castxml-cc-gnu ')
 
-            # Check for -std=xx flags passed to the compiler.
-            # A regex could be used but this is a moving target.
-            # See c++1z for example. It is preferable to have a defined
-            # list of what is allowed. http://clang.llvm.org/cxx_status.html
-            #
-            # Version 98 and 03 are only there in the case somebody is using
-            # these flags; this is the equivalent to not passing these flags.
-            standards = [
-                "-std=c++98",
-                "-std=c++03",
-                "-std=c++11",
-                "-std=c++14",
-                "-std=c++1z"]
+            if self.__cxx_std.is_implicit:
+                std_flag = ''
+            else:
+                std_flag = ' ' + self.__cxx_std.stdcxx + ' '
 
-            std_flag = ""
-            for standard in standards:
-                if standard in self.__config.cflags:
-                    std_flag = " " + standard + " "
-
-            # A -std= flag was passed, but is not in the list
-            if "-std=" in self.__config.cflags and std_flag == "":
-                raise(RuntimeError("Unknown -std=c++xx flag used !"))
-
-            if std_flag != "":
+            if std_flag:
                 cmd.append(
                     '"(" ' + self.__config.compiler_path + std_flag + '")"')
             else:
@@ -492,7 +475,8 @@ class source_reader_t(object):
         # void ddd(){ typedef typename X::Y YY;}
         # if I will fail on this bug next time, the right way to fix it may be
         # different
-        patcher.fix_calldef_decls(scanner_.calldefs(), scanner_.enums())
+        patcher.fix_calldef_decls(scanner_.calldefs(), scanner_.enums(),
+                                  self.__cxx_std)
         decls = [
             inst for inst in iter(
                 decls.values()) if isinstance(

--- a/pygccxml/utils/__init__.py
+++ b/pygccxml/utils/__init__.py
@@ -17,6 +17,7 @@ from .utils import remove_file_no_raise
 from .utils import normalize_path
 from .utils import find_xml_generator
 from .utils import get_tr1
+from .utils import cxx_standard
 
 # Version of xml generator which was used.
 xml_generator = None

--- a/pygccxml/utils/utils.py
+++ b/pygccxml/utils/utils.py
@@ -378,3 +378,94 @@ def get_tr1(name):
     if "tr1" in name:
         tr1 = "tr1::"
     return tr1
+
+
+class cxx_standard(object):
+    """Helper class for parsing the C++ standard version.
+
+    This class holds the C++ standard version the XML generator has been
+    configured with, and provides helpers functions for querying C++ standard
+    version related information.
+    """
+
+    __STD_CXX = {
+        '-std=c++98': 199711,
+        '-std=gnu++98': 199711,
+        '-std=c++03': 199711,
+        '-std=gnu++03': 199711,
+        '-std=c++0x': 201103,
+        '-std=gnu++0x': 201103,
+        '-std=c++11': 201103,
+        '-std=gnu++11': 201103,
+        '-std=c++1y': 201402,
+        '-std=gnu++1y': 201402,
+        '-std=c++14': 201402,
+        '-std=gnu++14': 201402,
+        '-std=c++1z': float('inf'),
+        '-std=gnu++1z': float('inf'),
+    }
+
+    def __init__(self, cflags):
+        """Class constructor that parses the XML generator's command line
+
+        Args:
+            cflags (str): cflags command line arguments passed to the XML
+                generator
+        """
+        super(cxx_standard, self).__init__()
+
+        self._stdcxx = None
+        self._is_implicit = False
+        for key in cxx_standard.__STD_CXX:
+            if key in cflags:
+                self._stdcxx = key
+                self._cplusplus = cxx_standard.__STD_CXX[key]
+
+        if not self._stdcxx:
+            if '-std=' in cflags:
+                raise RuntimeError('Unknown -std=c++xx flag used')
+
+            # Assume c++03 by default
+            self._stdcxx = '-std=c++03'
+            self._cplusplus = cxx_standard.__STD_CXX['-std=c++03']
+            self._is_implicit = True
+
+    @property
+    def stdcxx(self):
+        """Returns the -std=c++xx option passed to the constructor"""
+        return self._stdcxx
+
+    @property
+    def is_implicit(self):
+        """Indicates whether a -std=c++xx was specified"""
+        return self._is_implicit
+
+    @property
+    def is_cxx03(self):
+        """Returns true if -std=c++03 is being used"""
+        return self._cplusplus == cxx_standard.__STD_CXX['-std=c++03']
+
+    @property
+    def is_cxx11(self):
+        """Returns true if -std=c++11 is being used"""
+        return self._cplusplus == cxx_standard.__STD_CXX['-std=c++11']
+
+    @property
+    def is_cxx11_or_greater(self):
+        """Returns true if -std=c++11 or a newer standard is being used"""
+        return self._cplusplus >= cxx_standard.__STD_CXX['-std=c++11']
+
+    @property
+    def is_cxx14(self):
+        """Returns true if -std=c++14 is being used"""
+        return self._cplusplus == cxx_standard.__STD_CXX['-std=c++14']
+
+    @property
+    def is_cxx14_or_greater(self):
+        """Returns true if -std=c++14 or a newer standard is being used"""
+        return self._cplusplus >= cxx_standard.__STD_CXX['-std=c++14']
+
+    @property
+    def is_cxx1z(self):
+        """Returns true if -std=c++1z is being used"""
+        return self._cplusplus == cxx_standard.__STD_CXX['-std=c++1z']

--- a/unittests/data/patcher.hpp
+++ b/unittests/data/patcher.hpp
@@ -25,6 +25,22 @@ void fix_enum3( fruit arg=orange );
 
 }
 
+#if __cplusplus >= 201103L
+namespace ns4{
+
+enum class color {red, green, blue};
+void fix_enum4( color arg=color::blue );
+
+}
+
+namespace ns5{
+
+using namespace ns4;
+void fix_enum5( color arg=color::blue );
+
+}
+#endif
+
 typedef unsigned long long ull;
 void fix_numeric( ull arg=(ull)-1 );
 
@@ -74,6 +90,13 @@ struct st1{
 
 static int const DEFAULT_1 = 20;
 int fun2( int arg1=DEFAULT_1, int arg2=ns1::DEFAULT_1, long arg3=::ns1::st1::DEFAULT_2 );
+
+
+enum ACE_Log_Priority_Index
+{
+  LM_INVALID_BIT_INDEX = 32
+};
+static int log_priority_enabled(long priority_index = LM_INVALID_BIT_INDEX);
 
 
 /*struct default_arg_t{};*/


### PR DESCRIPTION
Given the following code

    namespace ns
    {
        enum color {red, green, blue};
        void test( color arg=blue );
    }

CastXML produces a fully qualified name for the default argument -
`::ns::color::blue`.

While this default argument string is valid for C++11 and later, and
indeed required if `color` were a scoped enumeration, the default
argument is invalid for C++03 code.

Prior to C++11, enumerator names were added to the enclosing scope, so
they could not be qualified using the enum-name. Hence, for C++03, the
default argument needs to be patched to say `::ns::blue`.