### PR TITLE
Various fixes for Windows

### DIFF
--- a/pygccxml/parser/source_reader.py
+++ b/pygccxml/parser/source_reader.py
@@ -341,6 +341,7 @@ class source_reader_t(object):
                             "Error occurred while running " +
                             self.__config.xml_generator.upper() + ": %s status:%s" %
                             (gccxml_msg, exit_status))
+                            
         except Exception:
             utils.remove_file_no_raise(xml_file, self.__config)
             raise

--- a/pygccxml/parser/source_reader.py
+++ b/pygccxml/parser/source_reader.py
@@ -332,10 +332,15 @@ class source_reader_t(object):
             else:
                 if gccxml_msg or exit_status or not \
                         os.path.isfile(xml_file):
-                    raise RuntimeError(
-                        "Error occurred while running " +
-                        self.__config.xml_generator.upper() + ": %s" %
-                        gccxml_msg)
+                    if gccxml_msg or exit_status:
+                        raise RuntimeError(
+                            "Error occurred while running " +
+                            self.__config.xml_generator.upper() + ": %s status:%s" %
+                            (gccxml_msg, exit_status))
+                    else:
+                        raise RuntimeError(
+                            "Error occurred while running " +
+                            self.__config.xml_generator.upper() + " xml file does not exist")
         except Exception:
             utils.remove_file_no_raise(xml_file, self.__config)
             raise

--- a/pygccxml/parser/source_reader.py
+++ b/pygccxml/parser/source_reader.py
@@ -332,15 +332,15 @@ class source_reader_t(object):
             else:
                 if gccxml_msg or exit_status or not \
                         os.path.isfile(xml_file):
-                    if gccxml_msg or exit_status:
+                    if not os.path.isfile(xml_file):
+                        raise RuntimeError(
+                            "Error occurred while running " +
+                            self.__config.xml_generator.upper() + " xml file does not exist")					
+                    else:
                         raise RuntimeError(
                             "Error occurred while running " +
                             self.__config.xml_generator.upper() + ": %s status:%s" %
                             (gccxml_msg, exit_status))
-                    else:
-                        raise RuntimeError(
-                            "Error occurred while running " +
-                            self.__config.xml_generator.upper() + " xml file does not exist")
         except Exception:
             utils.remove_file_no_raise(xml_file, self.__config)
             raise

--- a/pygccxml/parser/source_reader.py
+++ b/pygccxml/parser/source_reader.py
@@ -164,12 +164,9 @@ class source_reader_t(object):
 
         # Always require a compiler path at this point
         if self.__config.compiler_path is None:
-            raise(
-                RuntimeError,
-                "The compiler_path is not defined.\n"
-                "Please pass the compiler_path as argument to your "
-                "xml_generator_configuration_t(), or add it to your pygccxml "
-                "configuration file.")
+            raise(RuntimeError("""Please pass the compiler_path as argument to 
+			your xml_generator_configuration_t(), or add it to your pygccxml 
+                configuration file."""))
 
         # Platform specific options
         if platform.system() == 'Windows':
@@ -181,7 +178,7 @@ class source_reader_t(object):
                 cmd.append('--castxml-cc-gnu ' + self.__config.compiler_path)
             else:
                 # We are using msvc
-                cmd.append('--castxml-cc-msvc ' + self.__config.compiler_path)
+                cmd.append('--castxml-cc-msvc ' + '"%s"' % self.__config.compiler_path)
                 if 'msvc9' == self.__config.compiler:
                     cmd.append('-D"_HAS_TR1=0"')
         else:


### PR DESCRIPTION
I changed the multi-line exception. FYI

`Exception, "message"` is not compatible with Python 3 (not sure about Python 2). The compatible way to write it is `Exception("message")`


I also made a small change to a part, as it was only giving the `gccxml_msg` (which was an empty string), so I thought giving a return code may be helpful. 

This resolves #57 

EDIT: Not entirely sure why the pep8 checks are failing. I didn't edit all that much...
I'll read over the log later