### PR TITLE
Fix _HAS_TR1=0 definition for msvc9

### DIFF
--- a/pygccxml/parser/source_reader.py
+++ b/pygccxml/parser/source_reader.py
@@ -133,7 +133,7 @@ class source_reader_t(object):
                 cmd.append('--castxml-cc-msvc ' +
                            '"%s"' % self.__config.compiler_path)
                 if self.__config.compiler == 'msvc9':
-                    cmd.append('-D"_HAS_TR1=0"')
+                    cmd.append('"-D_HAS_TR1=0"')
         else:
 
             # On mac or linux, use gcc or clang (the flag is the same)


### PR DESCRIPTION
This can get expanded the wrong way with VS9 leading to a compile error.