### PR TITLE
Better support for the gnu compiler on Windows

### DIFF
--- a/pygccxml/parser/source_reader.py
+++ b/pygccxml/parser/source_reader.py
@@ -124,7 +124,7 @@ class source_reader_t(object):
         # Platform specific options
         if platform.system() == 'Windows':
 
-            if "mingw" in self.__config.compiler_path.lower():
+            if "mingw" or "g++" or "gcc" in self.__config.compiler_path.lower():
                 # Look at the compiler path. This is a bad way
                 # to find out if we are using mingw; but it
                 # should probably work in most of the cases


### PR DESCRIPTION
- MinGW isn't always installed in such a way that mingw is actually in the path to the compiler. Adding 'g++' and 'gcc' to the list of terms it looks for in the compiler path when on Windows helps finding all installation of the gnu compiler