### PR TITLE
Fix where cl error in cmake environment

### DIFF
--- a/pygccxml/parser/config.py
+++ b/pygccxml/parser/config.py
@@ -429,7 +429,8 @@ def create_compiler_path(xml_generator, compiler_path):
                 ['where', 'cl'],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE)
-            compiler_path = p.stdout.read().decode("utf-8").rstrip()
+            # Fix where cl error. In cmake environment there are more then one  Visual Studio path are found. 
+            compiler_path = p.stdout.read().decode("utf-8").rstrip().split("\r\n")[0].rstrip()
             p.wait()
             p.stdout.close()
             p.stderr.close()


### PR DESCRIPTION
If you start the parser with a cmake custom command in windows, it could be that you find two paths of visual studio.