### PR TITLE
handle null comparison

### DIFF
--- a/pygccxml/declarations/calldef.py
+++ b/pygccxml/declarations/calldef.py
@@ -85,6 +85,11 @@ class argument_t(object):
     def __lt__(self, other):
         if not isinstance(other, self.__class__):
             return self.__class__.__name__ < other.__class__.__name__
+        if other.default_value == None:
+            return False
+        if self.default_value == None:
+            return self.name < other.name \
+                and self.decl_type < other.decl_type
         return self.name < other.name \
             and self.default_value < other.default_value \
             and self.decl_type < other.decl_type


### PR DESCRIPTION
Fix mentioned in issue #56 

Since None is a supported value for default_value but python 3 does not support None comparison, an exception is thrown in the above line.

This PR fixes that.